### PR TITLE
Compatible with i2cdev driver

### DIFF
--- a/i2cdev/i2cdev.h
+++ b/i2cdev/i2cdev.h
@@ -30,6 +30,9 @@ SOFTWARE.
 #ifndef __I2CDEV_H__
 #define __I2CDEV_H__
 
+#include <driver/i2c.h>
+#include <esp_err.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -61,6 +64,32 @@ esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg,
 esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg,
         const void *out_data, size_t out_size);
 
+#define I2C_DEV_TAKE_MUTEX(dev) do { \
+        esp_err_t __ = ESP_OK; \
+        if (__ != ESP_OK) return __;\
+    } while (0)
+
+#define I2C_DEV_GIVE_MUTEX(dev) do { \
+        esp_err_t __ = ESP_OK; \
+        if (__ != ESP_OK) return __;\
+    } while (0)
+
+#define I2C_DEV_CHECK(dev, X) do { \
+        esp_err_t ___ = X; \
+        if (___ != ESP_OK) { \
+            I2C_DEV_GIVE_MUTEX(dev); \
+            return ___; \
+        } \
+    } while (0)
+
+#define I2C_DEV_CHECK_LOGE(dev, X, msg, ...) do { \
+        esp_err_t ___ = X; \
+        if (___ != ESP_OK) { \
+            I2C_DEV_GIVE_MUTEX(dev); \
+            ESP_LOGE(TAG, msg, ## __VA_ARGS__); \
+            return ___; \
+        } \
+    } while (0)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Compatible i2cdev 4 macro:
1. I2C_DEV_TAKE_MUTEX
2. I2C_DEV_GIVE_MUTEX
3. I2C_DEV_CHECK
4. I2C_DEV_CHECK_LOGE

[i2cdev.h](https://github.com/UncleRus/esp-idf-lib/blob/master/components/i2cdev/i2cdev.h#L193-L218)
