### PR TITLE
Move i2c r/w error output to debug level

### DIFF
--- a/i2c_manager/i2c_manager.c
+++ b/i2c_manager/i2c_manager.c
@@ -222,7 +222,7 @@ esp_err_t I2C_FN(_read)(i2c_port_t port, uint16_t addr, uint32_t reg, uint8_t *b
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);
@@ -271,7 +271,7 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);


### PR DESCRIPTION
Some i2c peripherals will perform a read and if it fails, fall back to first performing a write. Logging all of these as warnings not only liters the serial monitor, it adds significant enough delay between requests to cause other issues or preemption to another task.

Additionally, the error code is returned anyway, so the user should be handling them as they need/want to. Setting the output as debug seems to be the most appropriate course.