### PR TITLE
Adopted to ESP-IDF v5 latest compilation changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,12 @@ if (CONFIG_I2C_MANAGER_I2CDEV)
     list(APPEND INCLUDES "i2cdev")
 endif()
 
-idf_component_register(
-    SRCS ${SOURCES}
-    INCLUDE_DIRS ${INCLUDES}
-)
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
+    idf_component_register( SRCS ${SOURCES}
+                            INCLUDE_DIRS ${INCLUDES}
+                            REQUIRES driver)
+else()
+idf_component_register( SRCS ${SOURCES}
+                            INCLUDE_DIRS ${INCLUDES}
+                            )  
+endif()

--- a/i2c_manager/i2c_manager.c
+++ b/i2c_manager/i2c_manager.c
@@ -28,6 +28,7 @@ SOFTWARE.
 
 #include <stdint.h>
 #include <stddef.h>
+#include <inttypes.h>
 
 #include <esp_log.h>
 
@@ -168,7 +169,7 @@ esp_err_t I2C_FN(_init)(i2c_port_t port) {
 			ESP_LOGW(TAG, "If it was already open, we'll use it with whatever settings were used "
 			              "to open it. See I2C Manager README for details.");
 		} else {
-			ESP_LOGI(TAG, "Initialised port %d (SDA: %d, SCL: %d, speed: %d Hz.)",
+			ESP_LOGI(TAG, "Initialised port %d (SDA: %d, SCL: %d, speed: %"PRIu32" Hz.)",
 					 port, conf.sda_io_num, conf.scl_io_num, conf.master.clk_speed);
 		}
 
@@ -186,7 +187,7 @@ esp_err_t I2C_FN(_read)(i2c_port_t port, uint16_t addr, uint32_t reg, uint8_t *b
     // May seem weird, but init starts with a check if it's needed, no need for that check twice.
 	I2C_FN(_init)(port);
 
-   	ESP_LOGV(TAG, "Reading port %d, addr 0x%03x, reg 0x%04x", port, addr, reg);
+   	ESP_LOGV(TAG, "Reading port %d, addr 0x%03x, reg 0x%04"PRIu32, port, addr, reg);
 
 	TickType_t timeout = 0;
 	#if defined (I2C_ZERO)
@@ -239,7 +240,7 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
     // May seem weird, but init starts with a check if it's needed, no need for that check twice.
 	I2C_FN(_init)(port);
 
-    ESP_LOGV(TAG, "Writing port %d, addr 0x%03x, reg 0x%04x", port, addr, reg);
+    ESP_LOGV(TAG, "Writing port %d, addr 0x%03x, reg 0x%04"PRIu32, port, addr, reg);
 
 	TickType_t timeout = 0;
 	#if defined (I2C_ZERO)


### PR DESCRIPTION
- Added requirement for driver component
- Fixed issue with logging uint32_t values (see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler)

After this change it is possible to use this project from `idf_component.yml` like

``` YAML
i2c_manager:
    version: master
    git: git@github.com:pavlot/i2c_manager.git
```